### PR TITLE
#329: Fix release_droid_prepare_original_checksum workflow

### DIFF
--- a/.github/workflows/release_droid_prepare_original_checksum.yml
+++ b/.github/workflows/release_droid_prepare_original_checksum.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Install Go tools
         run: go install github.com/google/go-licenses@v1.2.1
       - name: Run tests and build with Maven
-        run: mvn --batch-mode clean verify --file pom.xml
+        run: |
+          mvn --batch-mode clean verify install \
+              -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+              -DtrimStackTrace=false
       - name: Prepare checksum
         run: find target -maxdepth 1 -name *.jar -exec sha256sum "{}" + > original_checksum
       - name: Upload checksum to the artifactory


### PR DESCRIPTION
Closes #329
release_droid_prepare_original_checksum.yml
matches ci-build.yml now