### PR TITLE
#397: Categorized Go dependencies as 'unknown' if module name does not contain version number

### DIFF
--- a/.project-keeper.yml
+++ b/.project-keeper.yml
@@ -69,7 +69,7 @@ sources:
 version:
   fromSource: project-keeper/pom.xml
 excludes:
-  - "W-PK-CORE-151: Pom file contains no reference to project-keeper-maven-plugin."
+  - regex: "W-PK-CORE-151: Pom file .* contains no reference to project-keeper-maven-plugin."
   - "E-PK-CORE-17: Missing required file: '.github/workflows/project-keeper-verify.yml'"
   - "E-PK-CORE-17: Missing required file: '.github/workflows/project-keeper.sh'"
 linkReplacements:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,4 +12,8 @@
             "-Djava.util.logging.config.file=src/test/resources/logging.properties"
         ]
     },
+    "sonarlint.connectedMode.project": {
+        "connectionId": "exasol",
+        "projectKey": "com.exasol:project-keeper-root"
+    },
 }

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [2.9.1](changes_2.9.1.md)
 * [2.9.0](changes_2.9.0.md)
 * [2.8.0](changes_2.8.0.md)
 * [2.7.0](changes_2.7.0.md)

--- a/doc/changes/changes_2.9.1.md
+++ b/doc/changes/changes_2.9.1.md
@@ -13,110 +13,44 @@ Fixed some bugs.
 
 ## Dependency Updates
 
-### Project-Keeper Shared Model Classes
-
-#### Plugin Dependency Updates
-
-* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
-* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
-* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1` to `3.0.0`
-* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.0` to `3.4.1`
-* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
-* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
-* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
-
 ### Project Keeper Core
 
 #### Compile Dependency Updates
 
-* Updated `com.exasol:project-keeper-shared-model-classes:2.8.0` to `2.9.1`
+* Updated `com.exasol:project-keeper-shared-model-classes:2.9.0` to `2.9.1`
 
 #### Runtime Dependency Updates
 
-* Updated `com.exasol:project-keeper-java-project-crawler:2.8.0` to `2.9.1`
+* Updated `com.exasol:project-keeper-java-project-crawler:2.9.0` to `2.9.1`
 
 #### Test Dependency Updates
 
-* Updated `com.exasol:project-keeper-shared-test-setup:2.8.0` to `2.9.1`
-
-#### Plugin Dependency Updates
-
-* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
-* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
-* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1` to `3.0.0`
-* Updated `org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M5` to `3.0.0-M7`
-* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.0` to `3.4.1`
-* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
-* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
-* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
+* Updated `com.exasol:project-keeper-shared-test-setup:2.9.0` to `2.9.1`
 
 ### Project Keeper Command Line Interface
 
 #### Compile Dependency Updates
 
-* Updated `com.exasol:project-keeper-core:2.8.0` to `2.9.1`
+* Updated `com.exasol:project-keeper-core:2.9.0` to `2.9.1`
 
 #### Test Dependency Updates
 
-* Updated `com.exasol:project-keeper-shared-test-setup:2.8.0` to `2.9.1`
-
-#### Plugin Dependency Updates
-
-* Updated `com.exasol:artifact-reference-checker-maven-plugin:0.4.0` to `0.4.2`
-* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
-* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
-* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1` to `3.0.0`
-* Updated `org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M5` to `3.0.0-M7`
-* Updated `org.apache.maven.plugins:maven-jar-plugin:3.2.2` to `3.3.0`
-* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.0` to `3.4.1`
-* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
-* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
-* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
+* Updated `com.exasol:project-keeper-shared-test-setup:2.9.0` to `2.9.1`
 
 ### Project Keeper Maven Plugin
 
 #### Compile Dependency Updates
 
-* Updated `com.exasol:project-keeper-core:2.8.0` to `2.9.1`
-
-#### Plugin Dependency Updates
-
-* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
-* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
-* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1` to `3.0.0`
-* Updated `org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M5` to `3.0.0-M7`
-* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.0` to `3.4.1`
-* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
-* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
-* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
+* Updated `com.exasol:project-keeper-core:2.9.0` to `2.9.1`
 
 ### Project Keeper Java Project Crawler
 
 #### Compile Dependency Updates
 
-* Updated `com.exasol:project-keeper-shared-model-classes:2.8.0` to `2.9.1`
-
-#### Plugin Dependency Updates
-
-* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
-* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
-* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1` to `3.0.0`
-* Updated `org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M5` to `3.0.0-M7`
-* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.0` to `3.4.1`
-* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
-* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
-* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
+* Updated `com.exasol:project-keeper-shared-model-classes:2.9.0` to `2.9.1`
 
 ### Project Keeper Shared Test Setup
 
 #### Compile Dependency Updates
 
-* Updated `com.exasol:project-keeper-shared-model-classes:2.8.0` to `2.9.1`
-
-#### Plugin Dependency Updates
-
-* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
-* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
-* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
-* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
-* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
+* Updated `com.exasol:project-keeper-shared-model-classes:2.9.0` to `2.9.1`

--- a/doc/changes/changes_2.9.1.md
+++ b/doc/changes/changes_2.9.1.md
@@ -1,0 +1,121 @@
+# Project Keeper 2.9.1, released 2022-??-??
+
+Code name: Minor Changes
+
+## Summary
+
+Fixed some bugs.
+
+## Bug Fix
+
+* #397: Categorized Go dependencies as 'unknown' if module name does not contain version number
+
+## Dependency Updates
+
+### Project-Keeper Shared Model Classes
+
+#### Plugin Dependency Updates
+
+* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
+* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
+* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1` to `3.0.0`
+* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.0` to `3.4.1`
+* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
+* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
+* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
+
+### Project Keeper Core
+
+#### Compile Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-model-classes:2.8.0` to `2.9.1`
+
+#### Runtime Dependency Updates
+
+* Updated `com.exasol:project-keeper-java-project-crawler:2.8.0` to `2.9.1`
+
+#### Test Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-test-setup:2.8.0` to `2.9.1`
+
+#### Plugin Dependency Updates
+
+* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
+* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
+* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1` to `3.0.0`
+* Updated `org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M5` to `3.0.0-M7`
+* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.0` to `3.4.1`
+* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
+* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
+* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
+
+### Project Keeper Command Line Interface
+
+#### Compile Dependency Updates
+
+* Updated `com.exasol:project-keeper-core:2.8.0` to `2.9.1`
+
+#### Test Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-test-setup:2.8.0` to `2.9.1`
+
+#### Plugin Dependency Updates
+
+* Updated `com.exasol:artifact-reference-checker-maven-plugin:0.4.0` to `0.4.2`
+* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
+* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
+* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1` to `3.0.0`
+* Updated `org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M5` to `3.0.0-M7`
+* Updated `org.apache.maven.plugins:maven-jar-plugin:3.2.2` to `3.3.0`
+* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.0` to `3.4.1`
+* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
+* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
+* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
+
+### Project Keeper Maven Plugin
+
+#### Compile Dependency Updates
+
+* Updated `com.exasol:project-keeper-core:2.8.0` to `2.9.1`
+
+#### Plugin Dependency Updates
+
+* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
+* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
+* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1` to `3.0.0`
+* Updated `org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M5` to `3.0.0-M7`
+* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.0` to `3.4.1`
+* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
+* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
+* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
+
+### Project Keeper Java Project Crawler
+
+#### Compile Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-model-classes:2.8.0` to `2.9.1`
+
+#### Plugin Dependency Updates
+
+* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
+* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
+* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1` to `3.0.0`
+* Updated `org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M5` to `3.0.0-M7`
+* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.0` to `3.4.1`
+* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
+* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
+* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`
+
+### Project Keeper Shared Test Setup
+
+#### Compile Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-model-classes:2.8.0` to `2.9.1`
+
+#### Plugin Dependency Updates
+
+* Updated `com.exasol:error-code-crawler-maven-plugin:1.1.2` to `1.2.1`
+* Updated `io.github.zlika:reproducible-build-maven-plugin:0.15` to `0.16`
+* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5` to `3.0.0-M7`
+* Updated `org.codehaus.mojo:flatten-maven-plugin:1.2.7` to `1.3.0`
+* Updated `org.codehaus.mojo:versions-maven-plugin:2.10.0` to `2.13.0`

--- a/doc/changes/changes_2.9.1.md
+++ b/doc/changes/changes_2.9.1.md
@@ -9,6 +9,7 @@ Fixed some bugs.
 ## Bug Fix
 
 * #397: Categorized Go dependencies as 'unknown' if module name does not contain version number
+* #398: Fixed dependency change report if file `package.json` or `go.mod` is missing in previous release.
 
 ## Dependency Updates
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -28,7 +28,7 @@
         </repository>
     </distributionManagement>
     <properties>
-        <revision>2.9.0</revision>
+        <revision>2.9.1</revision>
         <maven.version>3.8.6</maven.version>
         <junit.version>5.9.0</junit.version>
         <junit.platform.version>1.6.2</junit.platform.version>

--- a/project-keeper/src/main/java/com/exasol/projectkeeper/sources/analyze/generic/PreviousRelease.java
+++ b/project-keeper/src/main/java/com/exasol/projectkeeper/sources/analyze/generic/PreviousRelease.java
@@ -4,7 +4,6 @@ import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.Optional;
 
-import com.exasol.errorreporting.ExaError;
 import com.exasol.projectkeeper.shared.repository.GitRepository;
 import com.exasol.projectkeeper.shared.repository.TaggedCommit;
 
@@ -70,10 +69,7 @@ public class PreviousRelease {
         try {
             return repo.getFileFromCommit(this.file, tag.getCommit());
         } catch (final FileNotFoundException exception) {
-            throw new IllegalStateException(ExaError.messageBuilder("E-PK-CORE-134")
-                    .message("File {{module file}} does not exist at tag {{tag}}", //
-                            this.file, tag.getTag())
-                    .toString(), exception);
+            return null;
         }
     }
 }

--- a/project-keeper/src/main/java/com/exasol/projectkeeper/sources/analyze/generic/PreviousRelease.java
+++ b/project-keeper/src/main/java/com/exasol/projectkeeper/sources/analyze/generic/PreviousRelease.java
@@ -61,15 +61,15 @@ public class PreviousRelease {
     public Optional<String> getContent() {
         try (final GitRepository repo = this.git.getRepository(this.projectDir)) {
             return repo.findLatestReleaseCommit(this.version) //
-                    .map(tag -> getContent(repo, tag));
+                    .flatMap(tag -> getContent(repo, tag));
         }
     }
 
-    private String getContent(final GitRepository repo, final TaggedCommit tag) {
+    private Optional<String> getContent(final GitRepository repo, final TaggedCommit tag) {
         try {
-            return repo.getFileFromCommit(this.file, tag.getCommit());
+            return Optional.of(repo.getFileFromCommit(this.file, tag.getCommit()));
         } catch (final FileNotFoundException exception) {
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/project-keeper/src/main/java/com/exasol/projectkeeper/sources/analyze/golang/GolangDependencyType.java
+++ b/project-keeper/src/main/java/com/exasol/projectkeeper/sources/analyze/golang/GolangDependencyType.java
@@ -2,14 +2,18 @@ package com.exasol.projectkeeper.sources.analyze.golang;
 
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import com.exasol.errorreporting.ExaError;
 import com.exasol.projectkeeper.shared.dependencies.BaseDependency.Type;
 import com.exasol.projectkeeper.shared.dependencies.ProjectDependency;
 import com.exasol.projectkeeper.shared.dependencychanges.DependencyChange;
 
 class GolangDependencyType {
+
+    static final Logger LOGGER = Logger.getLogger(GolangDependencyType.class.getName());
+
     private final List<ProjectDependency> dependencies;
     private final Map<String, Type> types;
 
@@ -36,19 +40,46 @@ class GolangDependencyType {
     }
 
     private Type getTypeByPrefix(final String moduleName) {
-        if (moduleName.matches(".*/v\\d+")) {
-            final String moduleNamePrefix = moduleName.substring(0, moduleName.lastIndexOf("/"));
-            GolangDependencyChangeCalculator.LOGGER
-                    .finest(() -> "Found prefix '" + moduleNamePrefix + "' for module '" + moduleName + "'.");
-            return this.dependencies.stream() //
-                    .filter(dep -> dep.getName().startsWith(moduleNamePrefix)) //
-                    .map(ProjectDependency::getType) //
-                    .findFirst() //
-                    .orElse(Type.UNKNOWN);
-        } else {
-            throw new IllegalStateException(ExaError.messageBuilder("E-PK-CORE-158")
-                    .message("Unknown suffix for module {{module name}}.", moduleName).ticketMitigation().toString());
-        }
+        final DependencyMatcher dependencyMatcher = DependencyMatcher.forModule(moduleName);
+        return this.dependencies.stream() //
+                .filter(dependencyMatcher::matches) //
+                .map(ProjectDependency::getType) //
+                .findFirst() //
+                .orElse(Type.UNKNOWN);
     }
 
+    static interface DependencyMatcher {
+        static final Pattern PATTERN = Pattern.compile(".*/v\\d+");
+        static final DependencyMatcher NEVER = dep -> false;
+
+        static DependencyMatcher forModule(final String moduleName) {
+            if (!PATTERN.matcher(moduleName).matches()) {
+                return NEVER;
+            }
+            final String prefix = moduleName.substring(0, moduleName.lastIndexOf("/"));
+            LOGGER.finest(() -> "Found prefix '" + prefix + "' for module '" + moduleName + "'.");
+            return new PrefixMatcher(prefix);
+        }
+
+        /**
+         * Check if the name of a given dependency matches this matcher's prefix
+         *
+         * @param dependency dependency to check
+         * @return {@code true} if dependency matches
+         */
+        public boolean matches(final ProjectDependency dependency);
+
+        static class PrefixMatcher implements DependencyMatcher {
+            private final String prefix;
+
+            PrefixMatcher(final String prefix) {
+                this.prefix = prefix;
+            }
+
+            @Override
+            public boolean matches(final ProjectDependency dependency) {
+                return dependency.getName().startsWith(this.prefix);
+            }
+        }
+    }
 }

--- a/project-keeper/src/test/java/com/exasol/projectkeeper/sources/analyze/golang/GolangDependencyChangeCalculatorTest.java
+++ b/project-keeper/src/test/java/com/exasol/projectkeeper/sources/analyze/golang/GolangDependencyChangeCalculatorTest.java
@@ -3,8 +3,8 @@ package com.exasol.projectkeeper.sources.analyze.golang;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
@@ -69,8 +69,7 @@ class GolangDependencyChangeCalculatorTest {
     void missingDependencyTypeUnkownSuffix() {
         final DependencyChange change1 = change("dep1", "v1");
         simulateChanges(change1);
-        final IllegalStateException exception = assertThrows(IllegalStateException.class, () -> calculate());
-        assertThat(exception.getMessage(), startsWith("E-PK-CORE-158: Unknown suffix for module 'dep1'."));
+        assertReport(calculate(), Type.UNKNOWN, change1);
     }
 
     @Test

--- a/project-keeper/src/test/java/com/exasol/projectkeeper/sources/analyze/golang/GolangDependencyTypeTest.java
+++ b/project-keeper/src/test/java/com/exasol/projectkeeper/sources/analyze/golang/GolangDependencyTypeTest.java
@@ -1,0 +1,72 @@
+package com.exasol.projectkeeper.sources.analyze.golang;
+
+import static com.exasol.projectkeeper.shared.dependencies.BaseDependency.Type.COMPILE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.exasol.projectkeeper.shared.dependencies.BaseDependency.Type;
+import com.exasol.projectkeeper.shared.dependencies.ProjectDependency;
+import com.exasol.projectkeeper.shared.dependencychanges.DependencyChange;
+import com.exasol.projectkeeper.sources.analyze.golang.GolangDependencyType.DependencyMatcher;
+import com.exasol.projectkeeper.sources.analyze.golang.GolangDependencyType.DependencyMatcher.PrefixMatcher;
+
+class GolangDependencyTypeTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "abc", "a/v", "x/v_", "123", "123/a" })
+    void withoutVersion(final String moduleName) {
+        assertThat(DependencyMatcher.forModule(moduleName), not(isA(PrefixMatcher.class)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "abc/v1", "a/v123", "x/v0" })
+    void versioned(final String moduleName) {
+        assertThat(DependencyMatcher.forModule(moduleName), isA(PrefixMatcher.class));
+    }
+
+    @Test
+    void identical() {
+        verifySingle("abc", "abc", Type.COMPILE);
+    }
+
+    @Test
+    void golangRuntime() {
+        verifySingle(GolangServices.GOLANG_DEPENDENCY_NAME, "xxx", Type.COMPILE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "abc", "abc/v1", "x", "xxxx" })
+    void noMatch(final String moduleName) {
+        verifySingle(moduleName, "xxx", Type.UNKNOWN);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "xxx/v1", "xxx/v0" })
+    void prefix() {
+        verifySingle("xxx/v1", "xxx-suffix", Type.COMPILE);
+    }
+
+    private void verifySingle(final String moduleName, final String dependencyName, final Type expectedType) {
+        final GolangDependencyType testee = new GolangDependencyType(List.of( //
+                ProjectDependency.builder() //
+                        .name(dependencyName) //
+                        .type(COMPILE) //
+                        .build()));
+        final DependencyChange change = change(moduleName);
+        assertThat(testee.getType(change), equalTo(expectedType));
+    }
+
+    private DependencyChange change(final String moduleName) {
+        final DependencyChange change = mock(DependencyChange.class);
+        when(change.getArtifactId()).thenReturn(moduleName);
+        return change;
+    }
+}

--- a/project-keeper/src/test/java/com/exasol/projectkeeper/sources/analyze/npm/NpmServicesTest.java
+++ b/project-keeper/src/test/java/com/exasol/projectkeeper/sources/analyze/npm/NpmServicesTest.java
@@ -4,7 +4,6 @@ import static com.exasol.projectkeeper.sources.analyze.npm.NpmServices.LICENSE_C
 import static com.exasol.projectkeeper.sources.analyze.npm.NpmServices.LIST_DEPENDENCIES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -63,11 +62,8 @@ class NpmServicesTest {
     void previousNotFound() throws FileNotFoundException {
         final GitRepository repo = mock(GitRepository.class);
         when(repo.getFileFromCommit(any(), any())).thenThrow(new FileNotFoundException());
-        when(this.previousTag.getTag()).thenReturn(PREVIOUS_VERSION);
         final PackageJson current = currentPackageJson(PACKAGE_JSON_FILE);
-        final Exception exception = assertThrows(IllegalStateException.class, () -> retrievePrevious(repo, current));
-        assertThat(exception.getMessage(), equalTo(
-                "E-PK-CORE-134: File " + PACKAGE_JSON_FILE + " does not exist at tag '" + PREVIOUS_VERSION + "'"));
+        assertThat(retrievePrevious(repo, current), nullValue());
     }
 
     private PackageJson currentPackageJson(final Path relative) {


### PR DESCRIPTION
fixes #397
fixes #398