### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/dependencies_check.yml
+++ b/.github/workflows/dependencies_check.yml
@@ -42,9 +42,10 @@ jobs:
       - name: Install Project Keeper
         id: install-project-keeper
         run: |
-          mvn --batch-mode --threads 1C install -DskipTests \
-              -Dproject-keeper.skip=true -Dossindex.skip=true -Dmaven.javadoc.skip=true \
-              -Djacoco.skip=true -Derror-code-crawler.skip=true -Dreproducible.skip=true
+          mvn --batch-mode --threads 1C install \
+              -Dmaven.test.skip=true -Dproject-keeper.skip=true \
+              -Dossindex.skip=true -Dmaven.javadoc.skip=true \
+              -Derror-code-crawler.skip=true -Dreproducible.skip=true
       - name: Generate ossindex report
         id: ossindex-report
         run: |

--- a/.github/workflows/dependencies_update.yml
+++ b/.github/workflows/dependencies_update.yml
@@ -56,9 +56,10 @@ jobs:
       - name: Install Project Keeper
         id: install-project-keeper
         run: |
-          mvn --batch-mode --threads 1C install -DskipTests \
-              -Dproject-keeper.skip=true -Dossindex.skip=true -Dmaven.javadoc.skip=true \
-              -Djacoco.skip=true -Derror-code-crawler.skip=true -Dreproducible.skip=true
+          mvn --batch-mode --threads 1C install \
+              -Dmaven.test.skip=true -Dproject-keeper.skip=true \
+              -Dossindex.skip=true -Dmaven.javadoc.skip=true \
+              -Derror-code-crawler.skip=true -Dreproducible.skip=true
       - name: Update dependencies
         id: update-dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,13 @@ jobs:
           COMMIT_SHA: '${{ github.sha }}',
           GH_TOKEN: '${{ github.token }}'
         }
+      - name: Install Project Keeper
+        id: install-project-keeper
+        run: |
+          mvn --batch-mode --threads 1C install \
+              -Dmaven.test.skip=true -Dproject-keeper.skip=true \
+              -Dossindex.skip=true -Dmaven.javadoc.skip=true \
+              -Derror-code-crawler.skip=true -Dreproducible.skip=true
       - name: Verify release preconditions
         id: verify-release
         run: |

--- a/.project-keeper.yml
+++ b/.project-keeper.yml
@@ -131,9 +131,10 @@ build:
             id: install-project-keeper
             # This fixes https://github.com/exasol/project-keeper/issues/330
             run: |
-              mvn --batch-mode --threads 1C install -DskipTests \
-                  -Dproject-keeper.skip=true -Dossindex.skip=true -Dmaven.javadoc.skip=true \
-                  -Djacoco.skip=true -Derror-code-crawler.skip=true -Dreproducible.skip=true
+              mvn --batch-mode --threads 1C install \
+                  -Dmaven.test.skip=true -Dproject-keeper.skip=true \
+                  -Dossindex.skip=true -Dmaven.javadoc.skip=true \
+                  -Derror-code-crawler.skip=true -Dreproducible.skip=true
 
     # [itest->dsn~customize-build-process.dependency-update~0]
     - name: "dependencies_update.yml"
@@ -145,6 +146,22 @@ build:
             id: install-project-keeper
             # This fixes https://github.com/exasol/project-keeper/issues/330
             run: |
-              mvn --batch-mode --threads 1C install -DskipTests \
-                  -Dproject-keeper.skip=true -Dossindex.skip=true -Dmaven.javadoc.skip=true \
-                  -Djacoco.skip=true -Derror-code-crawler.skip=true -Dreproducible.skip=true
+              mvn --batch-mode --threads 1C install \
+                  -Dmaven.test.skip=true -Dproject-keeper.skip=true \
+                  -Dossindex.skip=true -Dmaven.javadoc.skip=true \
+                  -Derror-code-crawler.skip=true -Dreproducible.skip=true
+
+    # [itest->dsn~customize-build-process.release~0]
+    - name: "release.yml"
+      stepCustomizations:
+        - action: INSERT_AFTER
+          stepId: check-ci-build-status
+          content:
+            name: Install Project Keeper
+            id: install-project-keeper
+            # Required for running PK verify-release
+            run: |
+              mvn --batch-mode --threads 1C install \
+                  -Dmaven.test.skip=true -Dproject-keeper.skip=true \
+                  -Dossindex.skip=true -Dmaven.javadoc.skip=true \
+                  -Derror-code-crawler.skip=true -Dreproducible.skip=true

--- a/doc/requirements/design.md
+++ b/doc/requirements/design.md
@@ -432,7 +432,7 @@ PK allows customizing workflow steps in GitHub workflow `release.yml`.
 Covers:
 * [`req~customize-build-process~0`](system_requirements.md#customize-build-process)
 
-Needs: impl, utest
+Needs: impl, utest, itest
 
 #### Customize GitHub Workflow `dependencies_check.yml`
 `dsn~customize-build-process.dependency-check~0`


### PR DESCRIPTION
Release build failed, because it used the previous PK version for running `project-keeper:verify-release`. This installs PK before running `verify-release`.

https://github.com/exasol/project-keeper/actions/runs/8568080371/job/23481492974