### PR TITLE
#756: Upgrade SonarQube analysis runtime to Java 21

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,8 +54,8 @@ jobs:
         with:
           distribution: temurin
           java-version: |-
-            11
             17
+            21
           cache: maven
       - name: Set up Go
         id: setup-go
@@ -231,8 +231,8 @@ jobs:
         with:
           distribution: temurin
           java-version: |-
-            11
             17
+            21
           cache: maven
           server-id: ossindex
           server-username: OSSINDEX_USERNAME
@@ -309,8 +309,8 @@ jobs:
         with:
           distribution: temurin
           java-version: |-
-            11
             17
+            21
           cache: maven
       - name: Install Project Keeper before check-release
         id: install-project-keeper

--- a/.github/workflows/dependencies_check.yml
+++ b/.github/workflows/dependencies_check.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           distribution: temurin
           java-version: |-
-            11
             17
+            21
           cache: maven
           server-id: ossindex
           server-username: OSSINDEX_USERNAME

--- a/.github/workflows/dependencies_update.yml
+++ b/.github/workflows/dependencies_update.yml
@@ -46,8 +46,8 @@ jobs:
         with:
           distribution: temurin
           java-version: |-
-            11
             17
+            21
           cache: maven
       - name: Print issues
         id: debug-print-issues

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,8 +87,8 @@ jobs:
         with:
           distribution: temurin
           java-version: |-
-            11
             17
+            21
           server-id: maven-central-portal
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -101,8 +101,8 @@ jobs:
         with:
           distribution: temurin
           java-version: |-
-            11
             17
+            21
           cache: maven
       - name: Fail if not running on main or release branch
         id: check-main-or-release-branch

--- a/dependencies.md
+++ b/dependencies.md
@@ -12,36 +12,37 @@
 | [Apache Maven Deploy Plugin][4]                        | [Apache-2.0][1]                      |
 | [error-code-crawler-maven-plugin][5]                   | [MIT License][6]                     |
 | [org.sonatype.ossindex.maven:ossindex-maven-plugin][7] | [ASL2][8]                            |
+| [SonarQube Scanner for Maven][9]                       | [GNU LGPL 3][10]                     |
 
 ## Project Keeper Shared Model Classes
 
 ### Compile Dependencies
 
-| Dependency                       | License                                                                                                        |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| [Jakarta JSON Processing API][9] | [Eclipse Public License 2.0][10]; [GNU General Public License, version 2 with the GNU Classpath Exception][11] |
-| [Jakarta JSON Binding API][12]   | [Eclipse Public License 2.0][10]; [GNU General Public License, version 2 with the GNU Classpath Exception][11] |
-| [Yasson][13]                     | [Eclipse Public License v. 2.0][14]; [Eclipse Distribution License v. 1.0][15]                                 |
-| [error-reporting-java][16]       | [MIT License][17]                                                                                              |
-| [JGit - Core][18]                | [BSD-3-Clause][19]                                                                                             |
+| Dependency                        | License                                                                                                        |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [Jakarta JSON Processing API][11] | [Eclipse Public License 2.0][12]; [GNU General Public License, version 2 with the GNU Classpath Exception][13] |
+| [Jakarta JSON Binding API][14]    | [Eclipse Public License 2.0][12]; [GNU General Public License, version 2 with the GNU Classpath Exception][13] |
+| [Yasson][15]                      | [Eclipse Public License v. 2.0][16]; [Eclipse Distribution License v. 1.0][17]                                 |
+| [error-reporting-java][18]        | [MIT License][19]                                                                                              |
+| [JGit - Core][20]                 | [BSD-3-Clause][21]                                                                                             |
 
 ### Test Dependencies
 
 | Dependency                                 | License                           |
 | ------------------------------------------ | --------------------------------- |
-| [JUnit5 System Extensions][20]             | [Eclipse Public License v2.0][14] |
-| [EqualsVerifier \| release normal jar][21] | [Apache License, Version 2.0][1]  |
-| [to-string-verifier][22]                   | [MIT License][23]                 |
-| [mockito-core][24]                         | [MIT][25]                         |
-| [SLF4J JDK14 Provider][26]                 | [MIT][27]                         |
-| [JUnit Jupiter (Aggregator)][28]           | [Eclipse Public License v2.0][29] |
-| [Hamcrest][30]                             | [BSD-3-Clause][31]                |
+| [JUnit5 System Extensions][22]             | [Eclipse Public License v2.0][16] |
+| [EqualsVerifier \| release normal jar][23] | [Apache License, Version 2.0][1]  |
+| [to-string-verifier][24]                   | [MIT License][25]                 |
+| [mockito-core][26]                         | [MIT][27]                         |
+| [SLF4J JDK14 Provider][28]                 | [MIT][29]                         |
+| [JUnit Jupiter (Aggregator)][30]           | [Eclipse Public License v2.0][31] |
+| [Hamcrest][32]                             | [BSD-3-Clause][33]                |
 
 ### Plugin Dependencies
 
 | Dependency                                             | License                                       |
 | ------------------------------------------------------ | --------------------------------------------- |
-| [SonarQube Scanner for Maven][32]                      | [GNU LGPL 3][33]                              |
+| [SonarQube Scanner for Maven][9]                       | [GNU LGPL 3][10]                              |
 | [Apache Maven Toolchains Plugin][34]                   | [Apache-2.0][1]                               |
 | [Apache Maven Compiler Plugin][35]                     | [Apache-2.0][1]                               |
 | [Apache Maven Enforcer Plugin][0]                      | [Apache-2.0][1]                               |
@@ -75,9 +76,9 @@
 | ----------------------------------------- | --------------------------------------------- |
 | [Project Keeper shared model classes][58] | [The MIT License][59]                         |
 | [org.xmlunit:xmlunit-core][60]            | [The Apache Software License, Version 2.0][8] |
-| [error-reporting-java][16]                | [MIT License][17]                             |
+| [error-reporting-java][18]                | [MIT License][19]                             |
 | [Markdown Generator][61]                  | [The Apache Software License, Version 2.0][8] |
-| [semver4j][62]                            | [The MIT License][23]                         |
+| [semver4j][62]                            | [The MIT License][25]                         |
 | [SnakeYAML][63]                           | [Apache License, Version 2.0][8]              |
 | [SnakeYAML Engine][64]                    | [Apache License, Version 2.0][8]              |
 | [Maven Model][65]                         | [Apache-2.0][1]                               |
@@ -90,14 +91,14 @@
 | [Project Keeper shared test setup][58]     | [The MIT License][59]                         |
 | [Maven Project Version Getter][68]         | [MIT License][69]                             |
 | [org.xmlunit:xmlunit-matchers][60]         | [The Apache Software License, Version 2.0][8] |
-| [mockito-junit-jupiter][24]                | [MIT][25]                                     |
+| [mockito-junit-jupiter][26]                | [MIT][27]                                     |
 | [Maven Plugin Integration Testing][70]     | [MIT License][71]                             |
-| [EqualsVerifier \| release normal jar][21] | [Apache License, Version 2.0][1]              |
-| [to-string-verifier][22]                   | [MIT License][23]                             |
-| [junit-pioneer][72]                        | [Eclipse Public License v2.0][29]             |
-| [SLF4J JDK14 Provider][26]                 | [MIT][27]                                     |
-| [JUnit Jupiter (Aggregator)][28]           | [Eclipse Public License v2.0][29]             |
-| [Hamcrest][30]                             | [BSD-3-Clause][31]                            |
+| [EqualsVerifier \| release normal jar][23] | [Apache License, Version 2.0][1]              |
+| [to-string-verifier][24]                   | [MIT License][25]                             |
+| [junit-pioneer][72]                        | [Eclipse Public License v2.0][31]             |
+| [SLF4J JDK14 Provider][28]                 | [MIT][29]                                     |
+| [JUnit Jupiter (Aggregator)][30]           | [Eclipse Public License v2.0][31]             |
+| [Hamcrest][32]                             | [BSD-3-Clause][33]                            |
 
 ### Runtime Dependencies
 
@@ -109,7 +110,7 @@
 
 | Dependency                                             | License                                       |
 | ------------------------------------------------------ | --------------------------------------------- |
-| [SonarQube Scanner for Maven][32]                      | [GNU LGPL 3][33]                              |
+| [SonarQube Scanner for Maven][9]                       | [GNU LGPL 3][10]                              |
 | [Apache Maven Toolchains Plugin][34]                   | [Apache-2.0][1]                               |
 | [Apache Maven JAR Plugin][73]                          | [Apache-2.0][1]                               |
 | [Apache Maven Compiler Plugin][35]                     | [Apache-2.0][1]                               |
@@ -145,7 +146,7 @@
 | Dependency                 | License               |
 | -------------------------- | --------------------- |
 | [Project Keeper Core][58]  | [The MIT License][59] |
-| [error-reporting-java][16] | [MIT License][17]     |
+| [error-reporting-java][18] | [MIT License][19]     |
 | [Maven Model][65]          | [Apache-2.0][1]       |
 
 ### Test Dependencies
@@ -154,21 +155,21 @@
 | -------------------------------------- | --------------------------------- |
 | [Project Keeper shared test setup][58] | [The MIT License][59]             |
 | [Maven Project Version Getter][68]     | [MIT License][69]                 |
-| [JUnit Jupiter (Aggregator)][28]       | [Eclipse Public License v2.0][29] |
-| [Hamcrest][30]                         | [BSD-3-Clause][31]                |
+| [JUnit Jupiter (Aggregator)][30]       | [Eclipse Public License v2.0][31] |
+| [Hamcrest][32]                         | [BSD-3-Clause][33]                |
 
 ### Runtime Dependencies
 
 | Dependency                 | License   |
 | -------------------------- | --------- |
-| [SLF4J API Module][26]     | [MIT][27] |
-| [SLF4J JDK14 Provider][26] | [MIT][27] |
+| [SLF4J API Module][28]     | [MIT][29] |
+| [SLF4J JDK14 Provider][28] | [MIT][29] |
 
 ### Plugin Dependencies
 
 | Dependency                                             | License                                       |
 | ------------------------------------------------------ | --------------------------------------------- |
-| [SonarQube Scanner for Maven][32]                      | [GNU LGPL 3][33]                              |
+| [SonarQube Scanner for Maven][9]                       | [GNU LGPL 3][10]                              |
 | [Apache Maven Toolchains Plugin][34]                   | [Apache-2.0][1]                               |
 | [Apache Maven Compiler Plugin][35]                     | [Apache-2.0][1]                               |
 | [Apache Maven Enforcer Plugin][0]                      | [Apache-2.0][1]                               |
@@ -207,7 +208,7 @@
 | [Maven Plugin Tools Java Annotations][79] | [Apache-2.0][1]       |
 | [Maven Plugin API][80]                    | [Apache-2.0][1]       |
 | [Maven Core][81]                          | [Apache-2.0][1]       |
-| [error-reporting-java][16]                | [MIT License][17]     |
+| [error-reporting-java][18]                | [MIT License][19]     |
 
 ### Test Dependencies
 
@@ -215,18 +216,18 @@
 | -------------------------------------- | --------------------------------------------- |
 | [Maven Project Version Getter][68]     | [MIT License][69]                             |
 | [org.xmlunit:xmlunit-matchers][60]     | [The Apache Software License, Version 2.0][8] |
-| [mockito-core][24]                     | [MIT][25]                                     |
+| [mockito-core][26]                     | [MIT][27]                                     |
 | [Maven Plugin Integration Testing][70] | [MIT License][71]                             |
-| [SLF4J JDK14 Provider][26]             | [MIT][27]                                     |
+| [SLF4J JDK14 Provider][28]             | [MIT][29]                                     |
 | [JaCoCo :: Agent][82]                  | [EPL-2.0][51]                                 |
-| [JUnit Jupiter (Aggregator)][28]       | [Eclipse Public License v2.0][29]             |
-| [Hamcrest][30]                         | [BSD-3-Clause][31]                            |
+| [JUnit Jupiter (Aggregator)][30]       | [Eclipse Public License v2.0][31]             |
+| [Hamcrest][32]                         | [BSD-3-Clause][33]                            |
 
 ### Plugin Dependencies
 
 | Dependency                                             | License                                       |
 | ------------------------------------------------------ | --------------------------------------------- |
-| [SonarQube Scanner for Maven][32]                      | [GNU LGPL 3][33]                              |
+| [SonarQube Scanner for Maven][9]                       | [GNU LGPL 3][10]                              |
 | [Apache Maven Toolchains Plugin][34]                   | [Apache-2.0][1]                               |
 | [Maven Plugin Plugin][83]                              | [Apache-2.0][1]                               |
 | [Apache Maven Compiler Plugin][35]                     | [Apache-2.0][1]                               |
@@ -264,9 +265,9 @@
 | [Project Keeper shared model classes][58] | [The MIT License][59] |
 | [Maven Plugin Tools Java Annotations][79] | [Apache-2.0][1]       |
 | [Maven Plugin API][80]                    | [Apache-2.0][1]       |
-| [error-reporting-java][16]                | [MIT License][17]     |
-| [JGit - Core][18]                         | [BSD-3-Clause][19]    |
-| [semver4j][62]                            | [The MIT License][23] |
+| [error-reporting-java][18]                | [MIT License][19]     |
+| [JGit - Core][20]                         | [BSD-3-Clause][21]    |
+| [semver4j][62]                            | [The MIT License][25] |
 | [Maven Core][81]                          | [Apache-2.0][1]       |
 
 ### Test Dependencies
@@ -276,19 +277,19 @@
 | [Project Keeper shared test setup][58] | [The MIT License][59]                         |
 | [Maven Project Version Getter][68]     | [MIT License][69]                             |
 | [org.xmlunit:xmlunit-matchers][60]     | [The Apache Software License, Version 2.0][8] |
-| [SLF4J JDK14 Provider][26]             | [MIT][27]                                     |
-| [mockito-core][24]                     | [MIT][25]                                     |
-| [mockito-junit-jupiter][24]            | [MIT][25]                                     |
+| [SLF4J JDK14 Provider][28]             | [MIT][29]                                     |
+| [mockito-core][26]                     | [MIT][27]                                     |
+| [mockito-junit-jupiter][26]            | [MIT][27]                                     |
 | [Maven Plugin Integration Testing][70] | [MIT License][71]                             |
 | [JaCoCo :: Agent][82]                  | [EPL-2.0][51]                                 |
-| [JUnit Jupiter (Aggregator)][28]       | [Eclipse Public License v2.0][29]             |
-| [Hamcrest][30]                         | [BSD-3-Clause][31]                            |
+| [JUnit Jupiter (Aggregator)][30]       | [Eclipse Public License v2.0][31]             |
+| [Hamcrest][32]                         | [BSD-3-Clause][33]                            |
 
 ### Plugin Dependencies
 
 | Dependency                                             | License                                       |
 | ------------------------------------------------------ | --------------------------------------------- |
-| [SonarQube Scanner for Maven][32]                      | [GNU LGPL 3][33]                              |
+| [SonarQube Scanner for Maven][9]                       | [GNU LGPL 3][10]                              |
 | [Apache Maven Toolchains Plugin][34]                   | [Apache-2.0][1]                               |
 | [Apache Maven Compiler Plugin][35]                     | [Apache-2.0][1]                               |
 | [Apache Maven Enforcer Plugin][0]                      | [Apache-2.0][1]                               |
@@ -324,20 +325,20 @@
 | ----------------------------------------- | -------------------------------- |
 | [Project Keeper shared model classes][58] | [The MIT License][59]            |
 | [SnakeYAML][63]                           | [Apache License, Version 2.0][8] |
-| [Hamcrest][30]                            | [BSD-3-Clause][31]               |
+| [Hamcrest][32]                            | [BSD-3-Clause][33]               |
 | [Maven Model][65]                         | [Apache-2.0][1]                  |
 
 ### Test Dependencies
 
 | Dependency                       | License                           |
 | -------------------------------- | --------------------------------- |
-| [JUnit Jupiter (Aggregator)][28] | [Eclipse Public License v2.0][29] |
+| [JUnit Jupiter (Aggregator)][30] | [Eclipse Public License v2.0][31] |
 
 ### Plugin Dependencies
 
 | Dependency                                             | License                                     |
 | ------------------------------------------------------ | ------------------------------------------- |
-| [SonarQube Scanner for Maven][32]                      | [GNU LGPL 3][33]                            |
+| [SonarQube Scanner for Maven][9]                       | [GNU LGPL 3][10]                            |
 | [Apache Maven Toolchains Plugin][34]                   | [Apache-2.0][1]                             |
 | [Apache Maven Javadoc Plugin][43]                      | [Apache-2.0][1]                             |
 | [Apache Maven Compiler Plugin][35]                     | [Apache-2.0][1]                             |
@@ -366,31 +367,31 @@
 [6]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
 [7]: https://sonatype.github.io/ossindex-maven/maven-plugin/
 [8]: http://www.apache.org/licenses/LICENSE-2.0.txt
-[9]: https://github.com/eclipse-ee4j/jsonp
-[10]: https://projects.eclipse.org/license/epl-2.0
-[11]: https://projects.eclipse.org/license/secondary-gpl-2.0-cp
-[12]: https://projects.eclipse.org/projects/ee4j.jsonb/jakarta.json.bind-api
-[13]: https://projects.eclipse.org/projects/ee4j.yasson
-[14]: http://www.eclipse.org/legal/epl-v20.html
-[15]: http://www.eclipse.org/org/documents/edl-v10.php
-[16]: https://github.com/exasol/error-reporting-java/
-[17]: https://github.com/exasol/error-reporting-java/blob/main/LICENSE
-[18]: https://www.eclipse.org/jgit/
-[19]: https://www.eclipse.org/org/documents/edl-v10.php
-[20]: https://github.com/itsallcode/junit5-system-extensions
-[21]: https://www.jqno.nl/equalsverifier
-[22]: https://github.com/jparams/to-string-verifier
-[23]: http://www.opensource.org/licenses/mit-license.php
-[24]: https://github.com/mockito/mockito
-[25]: https://opensource.org/licenses/MIT
-[26]: http://www.slf4j.org
-[27]: https://opensource.org/license/mit
-[28]: https://junit.org/
-[29]: https://www.eclipse.org/legal/epl-v20.html
-[30]: http://hamcrest.org/JavaHamcrest/
-[31]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
-[32]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
-[33]: http://www.gnu.org/licenses/lgpl.txt
+[9]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
+[10]: http://www.gnu.org/licenses/lgpl.txt
+[11]: https://github.com/eclipse-ee4j/jsonp
+[12]: https://projects.eclipse.org/license/epl-2.0
+[13]: https://projects.eclipse.org/license/secondary-gpl-2.0-cp
+[14]: https://projects.eclipse.org/projects/ee4j.jsonb/jakarta.json.bind-api
+[15]: https://projects.eclipse.org/projects/ee4j.yasson
+[16]: http://www.eclipse.org/legal/epl-v20.html
+[17]: http://www.eclipse.org/org/documents/edl-v10.php
+[18]: https://github.com/exasol/error-reporting-java/
+[19]: https://github.com/exasol/error-reporting-java/blob/main/LICENSE
+[20]: https://www.eclipse.org/jgit/
+[21]: https://www.eclipse.org/org/documents/edl-v10.php
+[22]: https://github.com/itsallcode/junit5-system-extensions
+[23]: https://www.jqno.nl/equalsverifier
+[24]: https://github.com/jparams/to-string-verifier
+[25]: http://www.opensource.org/licenses/mit-license.php
+[26]: https://github.com/mockito/mockito
+[27]: https://opensource.org/licenses/MIT
+[28]: http://www.slf4j.org
+[29]: https://opensource.org/license/mit
+[30]: https://junit.org/
+[31]: https://www.eclipse.org/legal/epl-v20.html
+[32]: http://hamcrest.org/JavaHamcrest/
+[33]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
 [34]: https://maven.apache.org/plugins/maven-toolchains-plugin/
 [35]: https://maven.apache.org/plugins/maven-compiler-plugin/
 [36]: https://www.mojohaus.org/flatten-maven-plugin/

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [5.7.4](changes_5.7.4.md)
 * [5.7.3](changes_5.7.3.md)
 * [5.7.2](changes_5.7.2.md)
 * [5.7.1](changes_5.7.1.md)

--- a/doc/changes/changes_5.7.4.md
+++ b/doc/changes/changes_5.7.4.md
@@ -1,0 +1,78 @@
+# Project Keeper 5.7.4, released 2026-07-16
+
+Code name: Upgrade SonarQube analysis runtime
+
+## Summary
+
+This release upgrade the Java version for the Maven build from 17 to 21. Background: SonarQube analysis now requires runtime Java 21.
+
+Please note that the Java version used for compiling and building the projects using project keeper will not change.
+
+## Bugfixes
+
+* #756: Upgrade SonarQube analysis runtime
+
+## Dependency Updates
+
+### Project Keeper Shared Model Classes
+
+#### Test Dependency Updates
+
+* Updated `org.junit.jupiter:junit-jupiter:6.1.1` to `6.1.2`
+
+### Project Keeper Core
+
+#### Compile Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-model-classes:5.7.3` to `5.7.4`
+
+#### Runtime Dependency Updates
+
+* Updated `com.exasol:project-keeper-java-project-crawler:5.7.3` to `5.7.4`
+
+#### Test Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-test-setup:5.7.3` to `5.7.4`
+* Updated `org.junit.jupiter:junit-jupiter:6.1.1` to `6.1.2`
+
+### Project Keeper Command Line Interface
+
+#### Compile Dependency Updates
+
+* Updated `com.exasol:project-keeper-core:5.7.3` to `5.7.4`
+
+#### Test Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-test-setup:5.7.3` to `5.7.4`
+* Updated `org.junit.jupiter:junit-jupiter:6.1.1` to `6.1.2`
+
+### Project Keeper Maven Plugin
+
+#### Compile Dependency Updates
+
+* Updated `com.exasol:project-keeper-core:5.7.3` to `5.7.4`
+
+#### Test Dependency Updates
+
+* Updated `org.junit.jupiter:junit-jupiter:6.1.1` to `6.1.2`
+
+### Project Keeper Java Project Crawler
+
+#### Compile Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-model-classes:5.7.3` to `5.7.4`
+
+#### Test Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-test-setup:5.7.3` to `5.7.4`
+* Updated `org.junit.jupiter:junit-jupiter:6.1.1` to `6.1.2`
+
+### Project Keeper Shared Test Setup
+
+#### Compile Dependency Updates
+
+* Updated `com.exasol:project-keeper-shared-model-classes:5.7.3` to `5.7.4`
+
+#### Test Dependency Updates
+
+* Updated `org.junit.jupiter:junit-jupiter:6.1.1` to `6.1.2`

--- a/doc/changes/changes_5.7.4.md
+++ b/doc/changes/changes_5.7.4.md
@@ -16,6 +16,12 @@ Please note that the Java version used for compiling and building the projects u
 
 ## Dependency Updates
 
+### Project Keeper Root Project
+
+#### Plugin Dependency Updates
+
+* Added `org.sonarsource.scanner.maven:sonar-maven-plugin:5.7.0.6970`
+
 ### Project Keeper Shared Model Classes
 
 #### Test Dependency Updates

--- a/doc/changes/changes_5.7.4.md
+++ b/doc/changes/changes_5.7.4.md
@@ -6,6 +6,8 @@ Code name: Upgrade SonarQube analysis runtime
 
 This release upgrade the Java version for the Maven build from 17 to 21. Background: SonarQube analysis now requires runtime Java 21.
 
+We also updated the Java version used in the "Next Java" CI build for projects using Java 25 to 26.
+
 Please note that the Java version used for compiling and building the projects using project keeper will not change.
 
 ## Bugfixes

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -18,7 +18,7 @@
         </license>
     </licenses>
     <properties>
-        <revision>5.7.3</revision>
+        <revision>5.7.4</revision>
         <ossindexSkip>false</ossindexSkip>
         <!-- Integration test ProjectKeeperMojoIT starts a Maven build which requires Java 17. -->
         <java.version>17</java.version>
@@ -156,7 +156,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>6.1.1</version>
+                <version>6.1.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
                     <skip>${ossindexSkip}</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <!-- Explicitly specify version to avoid a warning -->
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>5.7.0.6970</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
     <properties>
         <sonar.organization>exasol</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <!-- Avoid installing JDK 11 in CI -->
+        <java.version>17</java.version>
     </properties>
     <modules>
         <module>shared-model-classes</module>

--- a/project-keeper-maven-plugin/src/test/java/com/exasol/projectkeeper/plugin/MvnProjectWithProjectKeeperPluginWriter.java
+++ b/project-keeper-maven-plugin/src/test/java/com/exasol/projectkeeper/plugin/MvnProjectWithProjectKeeperPluginWriter.java
@@ -2,6 +2,7 @@ package com.exasol.projectkeeper.plugin;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.maven.model.*;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -21,6 +22,7 @@ public class MvnProjectWithProjectKeeperPluginWriter {
         this.model.setGroupId("com.exasol");
         this.model.setModelVersion("4.0.0");
         this.model.setDescription("my project description");
+        this.model.setProperties(new Properties());
         addProjectKeeperPlugin(projectKeeperVersion);
     }
 
@@ -36,6 +38,11 @@ public class MvnProjectWithProjectKeeperPluginWriter {
         dependency.setArtifactId(artifactId);
         dependency.setVersion(version);
         this.model.getDependencies().add(dependency);
+        return this;
+    }
+
+    public MvnProjectWithProjectKeeperPluginWriter withJavaVersion(final String javaVersion) {
+        this.model.getProperties().setProperty("java.version", javaVersion);
         return this;
     }
 

--- a/project-keeper-maven-plugin/src/test/java/com/exasol/projectkeeper/plugin/ProjectKeeperMojoIT.java
+++ b/project-keeper-maven-plugin/src/test/java/com/exasol/projectkeeper/plugin/ProjectKeeperMojoIT.java
@@ -57,9 +57,10 @@ class ProjectKeeperMojoIT {
             // git-commit-id-maven-plugin needs at least one commit
             git.commit().setMessage("initial commit").setAllowEmpty(true).call();
         }
-        new MvnProjectWithProjectKeeperPluginWriter(CURRENT_VERSION) //
-                .addDependency("org.slf4j", "slf4j-api", ORIGINAL_SLF4J_VERSION) //
-                .setArtifactFinalName("dummy-${project.version}") //
+        new MvnProjectWithProjectKeeperPluginWriter(CURRENT_VERSION)
+                .addDependency("org.slf4j", "slf4j-api", ORIGINAL_SLF4J_VERSION)
+                .setArtifactFinalName("dummy-${project.version}")
+                .withJavaVersion("17")
                 .writeAsPomToProject(this.projectDir);
         LOG.info(() -> "Running test " + test.getDisplayName() + " using project " + this.projectDir + "...");
         verifier = mavenIntegrationTestEnvironment.getVerifier(this.projectDir);

--- a/project-keeper/src/main/java/com/exasol/projectkeeper/validators/files/JavaVersionExtractor.java
+++ b/project-keeper/src/main/java/com/exasol/projectkeeper/validators/files/JavaVersionExtractor.java
@@ -10,7 +10,8 @@ import com.exasol.projectkeeper.sources.AnalyzedSource;
 
 class JavaVersionExtractor {
 
-    private static final String MAVEN_BUILD_JAVA_VERSION = "17";
+    // Sonar requires Java 21 for analysis
+    private static final String MAVEN_BUILD_JAVA_VERSION = "21";
     private final List<AnalyzedSource> sources;
 
     JavaVersionExtractor(final List<AnalyzedSource> sources) {
@@ -21,8 +22,8 @@ class JavaVersionExtractor {
         final Set<String> javaVersions = new HashSet<>();
         javaVersions.addAll(getSourceJavaVersions());
         javaVersions.add(MAVEN_BUILD_JAVA_VERSION);
-        return javaVersions.stream() //
-                .sorted(comparing(JavaVersionExtractor::parseVersion)) //
+        return javaVersions.stream()
+                .sorted(comparing(JavaVersionExtractor::parseVersion))
                 .toList();
     }
 
@@ -60,7 +61,10 @@ class JavaVersionExtractor {
         if (current < 21) {
             return "21";
         }
-        return "25";
+        if (current < 25) {
+            return "25";
+        }
+        return "26";
     }
 
     private double getCurrentLatestVersion() {

--- a/project-keeper/src/main/java/com/exasol/projectkeeper/validators/files/JavaVersionExtractor.java
+++ b/project-keeper/src/main/java/com/exasol/projectkeeper/validators/files/JavaVersionExtractor.java
@@ -68,14 +68,10 @@ class JavaVersionExtractor {
     }
 
     private double getCurrentLatestVersion() {
-        return getSourceJavaVersions().stream() //
-                .map(JavaVersionExtractor::parseVersion) //
-                .reduce(JavaVersionExtractor::takeLast) //
+        return getSourceJavaVersions().stream()
+                .map(JavaVersionExtractor::parseVersion)
+                .max(Double::compareTo)
                 .orElseThrow(() -> new IllegalStateException(
                         "No latest java version found in source java versions " + getSourceJavaVersions()));
-    }
-
-    private static double takeLast(final double first, final double second) {
-        return second;
     }
 }

--- a/project-keeper/src/test/java/com/exasol/projectkeeper/validators/files/JavaVersionExtractorTest.java
+++ b/project-keeper/src/test/java/com/exasol/projectkeeper/validators/files/JavaVersionExtractorTest.java
@@ -15,57 +15,59 @@ import com.exasol.projectkeeper.sources.*;
 
 class JavaVersionExtractorTest {
 
+    private static final String MVN_JAVA_VERSION = "21";
+
     @Test
     void noSources() {
-        assertThat(extract(), contains("17"));
+        assertThat(extract(), contains(MVN_JAVA_VERSION));
     }
 
     @Test
     void nonJavaSource() {
-        assertThat(extract(AnalyzedSourceImpl.builder().build()), contains("17"));
+        assertThat(extract(AnalyzedSourceImpl.builder().build()), contains(MVN_JAVA_VERSION));
     }
 
     @Test
     void javaSource() {
-        assertThat(extract(mavenSource("11")), contains("11", "17"));
+        assertThat(extract(mavenSource("11")), contains("11", MVN_JAVA_VERSION));
     }
 
     @Test
     void versionWithDot() {
-        assertThat(extract(mavenSource("1.2")), contains("1.2", "17"));
+        assertThat(extract(mavenSource("1.2")), contains("1.2", MVN_JAVA_VERSION));
     }
 
     @Test
     void versionWithTwoDot() {
-        assertThat(extract(mavenSource("1.2.3")), contains("1.2.3", "17"));
+        assertThat(extract(mavenSource("1.2.3")), contains("1.2.3", MVN_JAVA_VERSION));
     }
 
     @Test
     void sortedAscending() {
-        assertThat(extract(mavenSource("21"), mavenSource("17"), mavenSource("11")), contains("11", "17", "21"));
+        assertThat(extract(mavenSource("21"), mavenSource(MVN_JAVA_VERSION), mavenSource("11")), contains("11", MVN_JAVA_VERSION));
     }
 
     @Test
     void removesDuplicates() {
-        assertThat(extract(mavenSource("17"), mavenSource("17"), mavenSource("11")), contains("11", "17"));
+        assertThat(extract(mavenSource(MVN_JAVA_VERSION), mavenSource(MVN_JAVA_VERSION), mavenSource("11")), contains("11", MVN_JAVA_VERSION));
     }
 
     @Test
     void sortsNumerically() {
-        assertThat(extract(mavenSource("17.9"), mavenSource("8"), mavenSource("1.8"), mavenSource("17")),
-                contains("1.8", "8", "17", "17.9"));
+        assertThat(extract(mavenSource("17.9"), mavenSource("8"), mavenSource("1.8"), mavenSource(MVN_JAVA_VERSION)),
+                contains("1.8", "8", "17.9", MVN_JAVA_VERSION));
     }
 
     @Test
     void getNextVersionIgnoresOlderVersions() {
-        assertThat(nextVersion(mavenSource("17"), mavenSource("11")), equalTo("21"));
+        assertThat(nextVersion(mavenSource("21"), mavenSource("11")), equalTo("25"));
     }
 
     @ParameterizedTest
     @CsvSource({ "8, 11", "9, 11", "11, 17", "12, 17", "17, 21", "17.1, 21", "21, 25", "22, 25", "24, 25",
-            "26, 25", "27, 25" })
+            "25, 26", "26, 26", "27, 26" })
     void getNextVersion(final String currentVersion, final String nextVersion) {
-        assertThat(nextVersion(mavenSource(currentVersion)), equalTo(nextVersion));
+        assertThat("Next version for " + currentVersion, nextVersion(mavenSource(currentVersion)), equalTo(nextVersion));
     }
 
     AnalyzedMavenSource mavenSource(final String javaVersion) {

--- a/project-keeper/src/test/java/com/exasol/projectkeeper/validators/files/JavaVersionExtractorTest.java
+++ b/project-keeper/src/test/java/com/exasol/projectkeeper/validators/files/JavaVersionExtractorTest.java
@@ -63,6 +63,11 @@ class JavaVersionExtractorTest {
         assertThat(nextVersion(mavenSource("21"), mavenSource("11")), equalTo("25"));
     }
 
+    @Test
+    void getNextVersionUsesMaximumVersionBeforeThreshold() {
+        assertThat(nextVersion(mavenSource("25"), mavenSource("21")), equalTo("26"));
+    }
+
     @ParameterizedTest
     @CsvSource({ "8, 11", "9, 11", "11, 17", "12, 17", "17, 21", "17.1, 21", "21, 25", "22, 25", "24, 25",
             "25, 26", "26, 26", "27, 26" })


### PR DESCRIPTION
Closes #756

Build log before (see https://github.com/exasol/udf-debugging-java/actions/runs/29498452276/job/87621009029):
```
[INFO] --- sonar:5.7.0.6970:sonar (default-cli) @ udf-debugging-java ---
[INFO] Java 17.0.19 Eclipse Adoptium (64-bit)
[INFO] Linux 6.17.0-1020-azure (amd64)
[INFO] Communicating with SonarQube Cloud
[INFO] JRE provisioning: os[linux], arch[x86_64]
[INFO] Starting SonarScanner Engine...
[INFO] Java 21.0.11 Eclipse Adoptium (64-bit)
```

Build log after fix (see https://github.com/exasol/project-keeper/actions/runs/29501347937/job/87630764217?pr=757):
```
[INFO] --- sonar:5.7.0.6970:sonar (default-cli) @ project-keeper-root ---
[INFO] Java 21.0.11 Eclipse Adoptium (64-bit)
[INFO] Linux 6.17.0-1020-azure (amd64)
[INFO] Communicating with SonarQube Cloud
[INFO] JRE provisioning: os[linux], arch[x86_64]
[INFO] Starting SonarScanner Engine...
[INFO] Java 21.0.11 Eclipse Adoptium (64-bit)

```